### PR TITLE
Update log level of skipped files message

### DIFF
--- a/storage/folder.go
+++ b/storage/folder.go
@@ -40,7 +40,7 @@ func DeleteObjectsWhere(folder Folder, confirm bool, filter func(object1 Object)
 			tracelog.InfoLogger.Println("\twill be deleted: " + object.GetName())
 			filteredRelativePaths = append(filteredRelativePaths, object.GetName())
 		} else {
-			tracelog.InfoLogger.Println("\tskipped: " + object.GetName())
+			tracelog.DebugLogger.Println("\tskipped: " + object.GetName())
 		}
 	}
 	if len(filteredRelativePaths) == 0 {


### PR DESCRIPTION
Hello.

I suggest changing log level of "skipped" files because in production use we don't want to know about skipped files.

We will delete, and we need to know what will be deleted. Not what will be skipped.

The second reason.
When we use wal-g retain job, we have very big log files with a lot of messages like:
```
INFO: 2019/12/06 16:43:49.108388   skipped: wal_005/000000010000127700000071.lz4
INFO: 2019/12/06 16:43:49.108395   skipped: wal_005/000000010000127700000072.lz4
INFO: 2019/12/06 16:43:49.108406   skipped: wal_005/000000010000127700000073.lz4
INFO: 2019/12/06 16:43:49.108413   skipped: wal_005/000000010000127700000074.lz4
INFO: 2019/12/06 16:43:49.108424   skipped: wal_005/000000010000127700000075.lz4
INFO: 2019/12/06 16:43:49.108432   skipped: wal_005/000000010000127700000076.lz4
INFO: 2019/12/06 16:43:49.108443   skipped: wal_005/000000010000127700000077.lz4
INFO: 2019/12/06 16:43:49.108462   skipped: wal_005/000000010000127700000078.lz4
INFO: 2019/12/06 16:43:49.108473   skipped: wal_005/000000010000127700000079.lz4
INFO: 2019/12/06 16:43:49.108482   skipped: wal_005/00000001000012770000007A.lz4
INFO: 2019/12/06 16:43:49.108493   skipped: wal_005/00000001000012770000007B.lz4
INFO: 2019/12/06 16:43:49.108500   skipped: wal_005/00000001000012770000007C.lz4
INFO: 2019/12/06 16:43:49.108511   skipped: wal_005/00000001000012770000007D.lz4
INFO: 2019/12/06 16:43:49.108518   skipped: wal_005/00000001000012770000007E.lz4
INFO: 2019/12/06 16:43:49.108529   skipped: wal_005/00000001000012770000007F.lz4
INFO: 2019/12/06 16:43:49.108536   skipped: wal_005/000000010000127700000080.lz4
INFO: 2019/12/06 16:43:49.108547   skipped: wal_005/000000010000127700000081.lz4
INFO: 2019/12/06 16:43:49.108555   skipped: wal_005/000000010000127700000082.lz4
INFO: 2019/12/06 16:43:49.108565   skipped: wal_005/000000010000127700000083.lz4
INFO: 2019/12/06 16:43:49.108573   skipped: wal_005/000000010000127700000084.lz4
INFO: 2019/12/06 16:43:49.108583   skipped: wal_005/000000010000127700000085.lz4
INFO: 2019/12/06 16:43:49.108590   skipped: wal_005/000000010000127700000086.lz4
INFO: 2019/12/06 16:43:49.108603   skipped: wal_005/000000010000127700000087.lz4
INFO: 2019/12/06 16:43:49.108610   skipped: wal_005/000000010000127700000088.lz4
INFO: 2019/12/06 16:43:49.108621   skipped: wal_005/000000010000127700000089.lz4
INFO: 2019/12/06 16:43:49.108628   skipped: wal_005/00000001000012770000008A.lz4
INFO: 2019/12/06 16:43:49.108639   skipped: wal_005/00000001000012770000008B.lz4
INFO: 2019/12/06 16:43:49.108646   skipped: wal_005/00000001000012770000008C.lz4
INFO: 2019/12/06 16:43:49.108657   skipped: wal_005/00000001000012770000008D.lz4
INFO: 2019/12/06 16:43:49.108664   skipped: wal_005/00000001000012770000008E.lz4
INFO: 2019/12/06 16:43:49.108675   skipped: wal_005/00000001000012770000008F.lz4
INFO: 2019/12/06 16:43:49.108682   skipped: wal_005/000000010000127700000090.lz4
INFO: 2019/12/06 16:43:49.108693   skipped: wal_005/000000010000127700000091.lz4
INFO: 2019/12/06 16:43:49.108700   skipped: wal_005/000000010000127700000092.lz4
INFO: 2019/12/06 16:43:49.108711   skipped: wal_005/000000010000127700000093.lz4
INFO: 2019/12/06 16:43:49.108719   skipped: wal_005/000000010000127700000094.lz4
INFO: 2019/12/06 16:43:49.108730   skipped: wal_005/000000010000127700000095.lz4
INFO: 2019/12/06 16:43:49.108737   skipped: wal_005/000000010000127700000096.lz4
INFO: 2019/12/06 16:43:49.108748   skipped: wal_005/000000010000127700000097.lz4
INFO: 2019/12/06 16:43:49.108755   skipped: wal_005/000000010000127700000098.lz4
INFO: 2019/12/06 16:43:49.108766   skipped: wal_005/000000010000127700000099.lz4
INFO: 2019/12/06 16:43:49.108774   skipped: wal_005/00000001000012770000009A.lz4
INFO: 2019/12/06 16:43:49.108784   skipped: wal_005/00000001000012770000009B.lz4
INFO: 2019/12/06 16:43:49.108792   skipped: wal_005/00000001000012770000009C.lz4
INFO: 2019/12/06 16:43:49.108802   skipped: wal_005/00000001000012770000009D.lz4
INFO: 2019/12/06 16:43:49.108809   skipped: wal_005/00000001000012770000009E.lz4
INFO: 2019/12/06 16:43:49.108820   skipped: wal_005/00000001000012770000009F.lz4
INFO: 2019/12/06 16:43:49.108827   skipped: wal_005/0000000100001277000000A0.lz4
INFO: 2019/12/06 16:43:49.108840   skipped: wal_005/0000000100001277000000A1.lz4
INFO: 2019/12/06 16:43:49.108847   skipped: wal_005/0000000100001277000000A2.lz4
INFO: 2019/12/06 16:43:49.108858   skipped: wal_005/0000000100001277000000A3.lz4
```

I think it's good for debug on dev environment, but not in production use.