### PR TITLE
Add exponential backoff with an equal jitter for GCS uploading

### DIFF
--- a/gcs/folder.go
+++ b/gcs/folder.go
@@ -197,11 +197,12 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 	dataChunk := uploader.allocateBuffer()
 
 	for {
-		if chunkNum > uploader.maxChunkNum {
-			return NewError(
-				errors.Errorf("the total number of chunks is limited to %d", uploader.maxChunkNum),
-				 "Unable to create a new uploading chunk")
-		}
+		// TODO: should we check max chunk number?
+		//if chunkNum > uploader.maxChunkNum {
+		//	return NewError(
+		//		errors.Errorf("the total number of chunks is limited to %d", uploader.maxChunkNum),
+		//		"Unable to create a new uploading chunk")
+		//}
 
 		n, err := uploader.readChunk(content, dataChunk)
 		if err != nil && err != io.EOF {
@@ -219,7 +220,7 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 			data:  dataChunk,
 		}
 
-		if err := uploader.uploadChunk(ctx, object.NewWriter(ctx), chunk); err != nil {
+		if err := uploader.uploadChunk(ctx, chunk); err != nil {
 			return NewError(err, "Unable to copy to object")
 		}
 

--- a/gcs/folder_test.go
+++ b/gcs/folder_test.go
@@ -1,8 +1,13 @@
 package gcs
 
 import (
-	"github.com/wal-g/storages/storage"
+	"errors"
 	"testing"
+	"time"
+
+	gcs "cloud.google.com/go/storage"
+
+	"github.com/wal-g/storages/storage"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -32,4 +37,59 @@ func TestGSExactFolder(t *testing.T) {
 	assert.NoError(t, err)
 
 	storage.RunFolderTest(storageFolder, t)
+}
+
+type fakeReader struct{}
+
+func (f fakeReader) Read(_ []byte) (int, error) {
+	return 0, errors.New("failed to fake read")
+}
+
+func TestUploadingRetries(t *testing.T) {
+	MaxRetries = 3
+	folder := Folder{
+		bucket:         &gcs.BucketHandle{},
+		path:           "path",
+		contextTimeout: 2,
+	}
+
+	err := folder.PutObject("name", fakeReader{})
+	assert.EqualError(t, err, "GCS error : Unable to copy to object: failed to fake read")
+}
+
+func TestJitterDelay(t *testing.T) {
+	baseDelay := time.Second
+	delay := getJitterDelay(baseDelay)
+
+	assert.GreaterOrEqual(t, int64(delay), int64(baseDelay))
+	assert.LessOrEqual(t, int64(delay), int64(2*baseDelay))
+}
+
+func TestMinDuration(t *testing.T) {
+	testCases := []struct {
+		duration1           time.Duration
+		duration2           time.Duration
+		expectedMinDuration time.Duration
+	}{
+		{
+			duration1:           time.Second,
+			duration2:           5 * time.Second,
+			expectedMinDuration: time.Second,
+		},
+		{
+			duration1:           3 * time.Second,
+			duration2:           2 * time.Second,
+			expectedMinDuration: 2 * time.Second,
+		},
+		{
+			duration1:           time.Second,
+			duration2:           time.Second,
+			expectedMinDuration: time.Second,
+		},
+	}
+
+	for _, tc := range testCases {
+		result := minDuration(tc.duration1, tc.duration2)
+		assert.Equal(t, tc.expectedMinDuration, result)
+	}
 }

--- a/gcs/folder_test.go
+++ b/gcs/folder_test.go
@@ -47,8 +47,8 @@ func (f fakeReader) Read(_ []byte) (int, error) {
 
 func TestUploadingReaderFails(t *testing.T) {
 	folder := Folder{
-		bucket:         &gcs.BucketHandle{},
-		path:           "path",
+		bucket: &gcs.BucketHandle{},
+		path:   "path",
 	}
 
 	err := folder.PutObject("name", fakeReader{})

--- a/gcs/folder_test.go
+++ b/gcs/folder_test.go
@@ -45,16 +45,14 @@ func (f fakeReader) Read(_ []byte) (int, error) {
 	return 0, errors.New("failed to fake read")
 }
 
-func TestUploadingRetries(t *testing.T) {
-	MaxRetries = 3
+func TestUploadingReaderFails(t *testing.T) {
 	folder := Folder{
 		bucket:         &gcs.BucketHandle{},
 		path:           "path",
-		contextTimeout: 2,
 	}
 
 	err := folder.PutObject("name", fakeReader{})
-	assert.EqualError(t, err, "GCS error : Unable to copy to object: failed to fake read")
+	assert.EqualError(t, err, "GCS error : Unable to read a chunk of data to upload: failed to fake read")
 }
 
 func TestJitterDelay(t *testing.T) {

--- a/gcs/uploader.go
+++ b/gcs/uploader.go
@@ -1,0 +1,96 @@
+package gcs
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"math"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/wal-g/tracelog"
+)
+
+const (
+	defaultMaxChunkSize = 20 << 20
+)
+
+type Uploader struct {
+	writer           io.Writer
+	maxChunkNum      int
+	maxChunkSize     int64
+	writePosition    int64
+	baseRetryDelay   time.Duration
+	maxRetryDelay    time.Duration
+	maxUploadRetries int
+}
+
+type UploaderOptions func(*Uploader)
+
+type chunk struct {
+	name  string
+	index int
+	data  []byte
+}
+
+func NewUploader(writer io.Writer, options ...UploaderOptions) *Uploader {
+	u := &Uploader{
+		writer:           writer,
+		maxChunkNum:      MaxChunkNum,
+		maxChunkSize:     defaultMaxChunkSize,
+		baseRetryDelay:   BaseRetryDelay,
+		maxRetryDelay:    maxRetryDelay,
+		maxUploadRetries: MaxRetries,
+	}
+
+	for _, opt := range options {
+		opt(u)
+	}
+
+	return u
+}
+
+func (u *Uploader) allocateBuffer() []byte {
+	return make([]byte, u.maxChunkSize)
+}
+
+func (u *Uploader) resetBuffer(b *[]byte) {
+	*b = u.allocateBuffer()
+}
+
+func (u *Uploader) readChunk(content io.Reader, b []byte) (int, error) {
+	return io.LimitReader(content, u.maxChunkSize).Read(b)
+}
+
+func (u *Uploader) uploadChunk(ctx context.Context, writer io.Writer, chunk chunk) error {
+	var err error
+	timer := time.NewTimer(u.baseRetryDelay)
+	defer func() {
+		timer.Stop()
+	}()
+
+	for retry := 0; retry <= u.maxUploadRetries; retry++ {
+		var n int64
+		bufReader := bytes.NewReader(chunk.data[u.writePosition:])
+		n, err = io.Copy(writer, bufReader)
+		if err == nil {
+			return nil
+		}
+		u.writePosition += n
+
+		tracelog.ErrorLogger.Printf("Unable to copy to object %s, part %d, err: %v, retrying attempt %d", chunk.name, chunk.index, err, retry)
+
+		tempDelay := u.baseRetryDelay * time.Duration(math.Exp2(float64(retry)))
+		sleepInterval := minDuration(u.maxRetryDelay, getJitterDelay(tempDelay/2))
+
+		timer.Reset(sleepInterval)
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	return errors.Errorf("retry limit has been exceeded, total attempts: %d", u.maxUploadRetries)
+}

--- a/gcs/uploader.go
+++ b/gcs/uploader.go
@@ -70,13 +70,17 @@ func (u *Uploader) uploadChunk(ctx context.Context, chunk chunk) error {
 		timer.Stop()
 	}()
 
+	u.writePosition = 0
+
 	for retry := 0; retry <= u.maxUploadRetries; retry++ {
 		bufReader := bytes.NewReader(chunk.data[u.writePosition:chunk.size])
+
 		n, err := io.Copy(u.writer, bufReader)
-		u.writePosition += n
 		if err == nil {
 			return nil
 		}
+
+		u.writePosition += n
 
 		tracelog.ErrorLogger.Printf("Unable to copy to object %s, part %d, err: %v, retrying attempt %d", chunk.name, chunk.index, err, retry)
 

--- a/gcs/uploader.go
+++ b/gcs/uploader.go
@@ -62,7 +62,7 @@ func (u *Uploader) readChunk(content io.Reader, b []byte) (int, error) {
 	return io.LimitReader(content, u.maxChunkSize).Read(b)
 }
 
-func (u *Uploader) uploadChunk(ctx context.Context, writer io.Writer, chunk chunk) error {
+func (u *Uploader) uploadChunk(ctx context.Context, chunk chunk) error {
 	var err error
 	timer := time.NewTimer(u.baseRetryDelay)
 	defer func() {
@@ -72,7 +72,7 @@ func (u *Uploader) uploadChunk(ctx context.Context, writer io.Writer, chunk chun
 	for retry := 0; retry <= u.maxUploadRetries; retry++ {
 		var n int64
 		bufReader := bytes.NewReader(chunk.data[u.writePosition:])
-		n, err = io.Copy(writer, bufReader)
+		n, err = io.Copy(u.writer, bufReader)
 		if err == nil {
 			return nil
 		}

--- a/storage/testing.go
+++ b/storage/testing.go
@@ -22,7 +22,7 @@ func RunFolderTest(storageFolder Folder, t *testing.T) {
 	assert.NoError(t, err)
 	all, err := ioutil.ReadAll(readCloser)
 	assert.NoError(t, err)
-	assert.Equal(t, all, token)
+	assert.Equal(t, token, all)
 
 	err = sub1.PutObject("file1", strings.NewReader("data1"))
 	assert.NoError(t, err)
@@ -37,13 +37,13 @@ func RunFolderTest(storageFolder Folder, t *testing.T) {
 	objects, subFolders, err := storageFolder.ListFolder()
 	assert.NoError(t, err)
 	t.Log(subFolders[0].GetPath())
-	assert.Equal(t, objects[0].GetName(), "file0")
+	assert.Equal(t, "file0", objects[0].GetName())
 	assert.True(t, strings.HasSuffix(subFolders[0].GetPath(), "Sub1/"))
 
 	sublist, subFolders, err := sub1.ListFolder()
 	assert.NoError(t, err)
-	assert.Equal(t, len(subFolders), 0)
-	assert.Equal(t, len(sublist), 1)
+	assert.Equal(t, 0, len(subFolders))
+	assert.Equal(t, 1, len(sublist))
 	assert.Equal(t, sublist[0].GetName(), "file1")
 
 	data, err := sub1.ReadObject("file1")


### PR DESCRIPTION
To resolve the issue: https://github.com/wal-g/wal-g/issues/266
Add exponential backoff with an equal jitter during interaction with GCS