### PR TITLE
GCS chunk uploader

### DIFF
--- a/gcs/folder.go
+++ b/gcs/folder.go
@@ -191,7 +191,7 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 	ctx, cancel := folder.createTimeoutContext()
 	defer cancel()
 
-	uploader := NewUploader(object.NewWriter(ctx))
+	uploader := NewUploader(object.NewWriter(ctx), object)
 
 	chunkNum := 0
 	dataChunk := uploader.allocateBuffer()

--- a/gcs/folder.go
+++ b/gcs/folder.go
@@ -191,10 +191,11 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 	ctx, cancel := folder.createTimeoutContext()
 	defer cancel()
 
-	uploader := NewUploader(object.NewWriter(ctx), object)
+	uploader := NewUploader(object.NewWriter(ctx))
 
 	chunkNum := 0
 	dataChunk := uploader.allocateBuffer()
+	tmpChunks := make([]*gcs.ObjectHandle, 0)
 
 	for {
 		n, err := fillBuffer(content, dataChunk)
@@ -207,29 +208,57 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 			break
 		}
 
+		tmpChunkName := folder.joinPath(name+"_chunks", "chunk"+strconv.Itoa(chunkNum))
+		objectChunk := folder.bucket.Object(folder.joinPath(folder.path, tmpChunkName))
+		uploader := NewUploader(objectChunk.NewWriter(ctx))
+
 		chunk := chunk{
-			name:  name,
+			name:  tmpChunkName,
 			index: chunkNum,
 			data:  dataChunk,
 			size:  n,
 		}
 
-		if err := uploader.uploadChunk(ctx, chunk); err != nil {
+		if err := uploader.retry(ctx, uploader.upload(chunk)); err != nil {
 			return NewError(err, "Unable to copy to object")
 		}
 
+		tmpChunks = append(tmpChunks, objectChunk)
+
 		chunkNum++
 		uploader.resetBuffer(&dataChunk)
+
+		if err := uploader.writer.Close(); err != nil {
+			return NewError(err, "Unable to Close object")
+		}
 
 		if err == io.EOF {
 			break
 		}
 	}
 
-	tracelog.DebugLogger.Printf("Put %v done\n", name)
-	if err := uploader.writer.Close(); err != nil {
-		return NewError(err, "Unable to Close object")
+	tracelog.InfoLogger.Printf("Compose file %v from chunks\n", object.ObjectName())
+
+	composeChunksFunc := func() error {
+		_, err := object.ComposerFrom(tmpChunks...).Run(ctx)
+		return err
 	}
+
+	if err := uploader.retry(ctx, composeChunksFunc); err != nil {
+		return NewError(err, "Unable to copy to object")
+	}
+
+	tracelog.InfoLogger.Printf("Remove temporary chunks for %v\n", object.ObjectName())
+
+	for _, tmpChunk := range tmpChunks {
+		removeTempChunksFunc := func() error { return tmpChunk.Delete(ctx) }
+		if err := uploader.retry(ctx, removeTempChunksFunc); err != nil {
+			return NewError(err, "Unable to delete temporary chunks")
+		}
+	}
+
+	tracelog.DebugLogger.Printf("Put %v done\n", name)
+
 	return nil
 }
 

--- a/gcs/uploader.go
+++ b/gcs/uploader.go
@@ -69,7 +69,11 @@ func (u *Uploader) uploadChunk(ctx context.Context, chunk chunk) error {
 	u.writePosition = 0
 
 	for retry := 0; retry <= u.maxUploadRetries; retry++ {
-		if retry%5 == 0 {
+		if retry > 0 && retry%5 == 0 {
+			if err := u.writer.Close(); err != nil {
+				tracelog.ErrorLogger.Printf("Error on close writer: %v", err)
+			}
+
 			u.writer = u.objHandle.NewWriter(ctx)
 			tracelog.InfoLogger.Println("Update writer")
 		}

--- a/gcs/uploader.go
+++ b/gcs/uploader.go
@@ -17,9 +17,8 @@ const (
 )
 
 type Uploader struct {
-	writer           *storage.Writer
+	objHandle        *storage.ObjectHandle
 	maxChunkSize     int64
-	writePosition    int64
 	baseRetryDelay   time.Duration
 	maxRetryDelay    time.Duration
 	maxUploadRetries int
@@ -34,9 +33,9 @@ type chunk struct {
 	size  int
 }
 
-func NewUploader(writer *storage.Writer, options ...UploaderOptions) *Uploader {
+func NewUploader(objHandle *storage.ObjectHandle, options ...UploaderOptions) *Uploader {
 	u := &Uploader{
-		writer:           writer,
+		objHandle:        objHandle,
 		maxChunkSize:     defaultMaxChunkSize,
 		baseRetryDelay:   BaseRetryDelay,
 		maxRetryDelay:    maxRetryDelay,
@@ -54,38 +53,70 @@ func (u *Uploader) allocateBuffer() []byte {
 	return make([]byte, u.maxChunkSize)
 }
 
-func (u *Uploader) resetBuffer(b *[]byte) {
-	*b = u.allocateBuffer()
+// UploadChunk uploads ab object chunk to storage.
+func (u *Uploader) UploadChunk(ctx context.Context, chunk chunk) error {
+	return u.retry(ctx, u.getUploadFunc(chunk))
 }
 
-func (u *Uploader) upload(chunk chunk) func() error {
-	return func() error {
-		tracelog.InfoLogger.Printf("Upload %s, part %d\n", chunk.name, chunk.index)
+func (u *Uploader) getUploadFunc(chunk chunk) func(context.Context) error {
+	return func(ctx context.Context) error {
+		tracelog.DebugLogger.Printf("Upload %s, part %d\n", chunk.name, chunk.index)
 
-		bufReader := bytes.NewReader(chunk.data[u.writePosition:chunk.size])
+		writer := u.objHandle.NewWriter(ctx)
+		reader := bytes.NewReader(chunk.data[:chunk.size])
 
-		n, err := io.Copy(u.writer, bufReader)
+		defer func() {
+			if err := writer.Close(); err != nil {
+				tracelog.ErrorLogger.Printf("Unable to close object writer %s, part %d, err: %v", chunk.name, chunk.index, err)
+			}
+		}()
+
+		_, err := io.Copy(writer, reader)
 		if err == nil {
 			return nil
 		}
 
-		u.writePosition += n
+		tracelog.ErrorLogger.Printf("Unable to copy an object chunk %s, part %d, err: %v", chunk.name, chunk.index, err)
 
-		tracelog.ErrorLogger.Printf("Unable to copy to object %s, part %d, err: %v", chunk.name, chunk.index, err)
 		return err
 	}
 }
 
-func (u *Uploader) retry(ctx context.Context, retryFunc func() error) error {
+// ComposeObject composes an object from temporary chunks.
+func (u *Uploader) ComposeObject(ctx context.Context, tmpChunks []*storage.ObjectHandle) error {
+	return u.retry(ctx, u.getComposeFunc(tmpChunks))
+}
+
+func (u *Uploader) getComposeFunc(tmpChunks []*storage.ObjectHandle) func(context.Context) error {
+	return func(ctx context.Context) error {
+		_, err := u.objHandle.ComposerFrom(tmpChunks...).Run(ctx)
+		return err
+	}
+}
+
+// CleanUpChunks removes temporary chunks.
+func (u *Uploader) CleanUpChunks(ctx context.Context, tmpChunks []*storage.ObjectHandle) error {
+	for _, tmpChunk := range tmpChunks {
+		if err := u.retry(ctx, u.getCleanUpChunksFunc(tmpChunk)); err != nil {
+			return NewError(err, "Unable to delete a temporary chunk")
+		}
+	}
+
+	return nil
+}
+
+func (u *Uploader) getCleanUpChunksFunc(tmpChunk *storage.ObjectHandle) func(context.Context) error {
+	return func(ctx context.Context) error { return tmpChunk.Delete(ctx) }
+}
+
+func (u *Uploader) retry(ctx context.Context, retryableFunc func(ctx context.Context) error) error {
 	timer := time.NewTimer(u.baseRetryDelay)
 	defer func() {
 		timer.Stop()
 	}()
 
-	u.writePosition = 0
-
 	for retry := 0; retry <= u.maxUploadRetries; retry++ {
-		err := retryFunc()
+		err := retryableFunc(ctx)
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
Implement multipart uploading for small chunks, then composite uploaded objects using the provided API: https://cloud.google.com/storage/docs/composite-objects and clean up temporary chunks.