### PR TITLE
GCS: support customer-supplied encryption keys

### DIFF
--- a/gcs/folder_test.go
+++ b/gcs/folder_test.go
@@ -39,6 +39,19 @@ func TestGSExactFolder(t *testing.T) {
 	storage.RunFolderTest(storageFolder, t)
 }
 
+func TestGSFolderWithEncryptionKey(t *testing.T) {
+	t.Skip("Credentials needed to run GCP tests")
+
+	storageFolder, err := ConfigureFolder("gs://x4m-test/walg-bucket",
+		map[string]string{
+			EncryptionKey: "F2F90NxJ2LrC/ujDQVGFfHetdDgjIMyrDkkN1VqGNnw=",
+		})
+
+	assert.NoError(t, err)
+
+	storage.RunFolderTest(storageFolder, t)
+}
+
 type fakeReader struct{}
 
 func (f fakeReader) Read(_ []byte) (int, error) {

--- a/gcs/uploader.go
+++ b/gcs/uploader.go
@@ -75,6 +75,11 @@ func (u *Uploader) getUploadFunc(chunk chunk) func(context.Context) error {
 					err = closeErr
 				}
 			}
+
+			// Since compose sources must not have an encryption key, clean up it.
+			if err == nil {
+				*u.objHandle = *u.objHandle.Key(nil)
+			}
 		}()
 
 		_, err = io.Copy(writer, reader)
@@ -96,6 +101,11 @@ func (u *Uploader) ComposeObject(ctx context.Context, tmpChunks []*storage.Objec
 func (u *Uploader) getComposeFunc(tmpChunks []*storage.ObjectHandle) func(context.Context) error {
 	return func(ctx context.Context) error {
 		_, err := u.objHandle.ComposerFrom(tmpChunks...).Run(ctx)
+		// Since compose sources must not have an encryption key, clean up it.
+		if err == nil {
+			*u.objHandle = *u.objHandle.Key(nil)
+		}
+
 		return err
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/wal-g/tracelog v0.0.0-20190824100002-0ab2b054ff30
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	google.golang.org/api v0.28.0
 	gopkg.in/yaml.v2 v2.2.7 // indirect
 )

--- a/storage/testing.go
+++ b/storage/testing.go
@@ -2,11 +2,12 @@ package storage
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func RunFolderTest(storageFolder Folder, t *testing.T) {


### PR DESCRIPTION
As part of https://github.com/wal-g/wal-g/issues/791

Customer-managed encryption keys are incompatible with Composite Objects -- only Google-managed keys and Customer-supplied keys are https://cloud.google.com/storage/docs/encryption/customer-supplied-keys

For better security, one might want to avoid working with Google-managed keys. Therefore, support for Customer-supplied keys is needed in WAL-G

