### PR TITLE
set actual encryption key size for GCS Object handles

### DIFF
--- a/gcs/folder.go
+++ b/gcs/folder.go
@@ -50,7 +50,7 @@ func NewError(err error, format string, args ...interface{}) storage.Error {
 }
 
 func NewFolder(bucket *gcs.BucketHandle, path string, contextTimeout int, normalizePrefix bool, encryptionKey []byte) *Folder {
-	encryptionKeyCopy := make([]byte, encryptionKeySize)
+	encryptionKeyCopy := make([]byte, len(encryptionKey))
 	copy(encryptionKeyCopy, encryptionKey)
 
 	return &Folder{
@@ -107,7 +107,7 @@ func ConfigureFolder(prefix string, settings map[string]string) (storage.Folder,
 		}
 	}
 
-	encryptionKey := make([]byte, encryptionKeySize)
+	encryptionKey := make([]byte, 0)
 	if encodedCSEK, ok := settings[EncryptionKey]; ok {
 		decodedKey, err := base64.StdEncoding.DecodeString(encodedCSEK)
 		if err != nil {

--- a/gcs/folder_test.go
+++ b/gcs/folder_test.go
@@ -12,6 +12,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewFolder(t *testing.T) {
+	testCases := []struct {
+		bucketHandle    *gcs.BucketHandle
+		path            string
+		timeout         int
+		normalizePrefix bool
+		encryptionKey   []byte
+		folder          *Folder
+	}{
+		{
+			path:    "path",
+			timeout: 10,
+			folder:  &Folder{path: "path", contextTimeout: 10, encryptionKey: []byte{}},
+		},
+		{
+			path:            "path",
+			timeout:         10,
+			normalizePrefix: true,
+			encryptionKey:   []byte("test"),
+			folder:          &Folder{path: "path", contextTimeout: 10, normalizePrefix: true, encryptionKey: []byte("test")},
+		},
+	}
+
+	for _, tc := range testCases {
+		newFolder := NewFolder(tc.bucketHandle, tc.path, tc.timeout, tc.normalizePrefix, tc.encryptionKey)
+		assert.Equal(t, tc.folder, newFolder)
+	}
+}
+
 func TestGSFolder(t *testing.T) {
 	t.Skip("Credentials needed to run GCP tests")
 


### PR DESCRIPTION
Fix the issue in case if no encryption key is supplied: https://github.com/wal-g/wal-g/issues/791#issuecomment-727474936
The folder encryption key will not be set to a byte array of zeros in NewFolder.