### PR TITLE
Remove credentials provider settings

### DIFF
--- a/s3/session.go
+++ b/s3/session.go
@@ -88,7 +88,7 @@ func getDefaultConfig(settings map[string]string) *aws.Config {
 	// request.Retryer interface.
 	config := defaults.Get().Config.WithRegion(settings[RegionSetting])
 	config = request.WithRetryer(config, client.DefaultRetryer{NumMaxRetries: MaxRetries})
-
+	/*
 	provider := &credentials.StaticProvider{Value: credentials.Value{
 		AccessKeyID:     getFirstSettingOf(settings, []string{AccessKeyIdSetting, AccessKeySetting}),
 		SecretAccessKey: getFirstSettingOf(settings, []string{SecretAccessKeySetting, SecretKeySetting}),
@@ -103,7 +103,7 @@ func getDefaultConfig(settings map[string]string) *aws.Config {
 	})
 
 	config = config.WithCredentials(newCredentials)
-
+	*/
 	if logLevel, ok := settings[LogLevel]; ok {
 		config = config.WithLogLevel(func(s string) aws.LogLevelType {
 			switch s {

--- a/s3/session.go
+++ b/s3/session.go
@@ -88,22 +88,7 @@ func getDefaultConfig(settings map[string]string) *aws.Config {
 	// request.Retryer interface.
 	config := defaults.Get().Config.WithRegion(settings[RegionSetting])
 	config = request.WithRetryer(config, client.DefaultRetryer{NumMaxRetries: MaxRetries})
-	/*
-	provider := &credentials.StaticProvider{Value: credentials.Value{
-		AccessKeyID:     getFirstSettingOf(settings, []string{AccessKeyIdSetting, AccessKeySetting}),
-		SecretAccessKey: getFirstSettingOf(settings, []string{SecretAccessKeySetting, SecretKeySetting}),
-		SessionToken:    settings[SessionTokenSetting],
-	}}
-	providers := make([]credentials.Provider, 0)
-	providers = append(providers, provider)
-	providers = append(providers, defaults.CredProviders(config, defaults.Handlers())...)
-	newCredentials := credentials.NewCredentials(&credentials.ChainProvider{
-		VerboseErrors: aws.BoolValue(config.CredentialsChainVerboseErrors),
-		Providers:     providers,
-	})
-
-	config = config.WithCredentials(newCredentials)
-	*/
+	
 	if logLevel, ok := settings[LogLevel]; ok {
 		config = config.WithLogLevel(func(s string) aws.LogLevelType {
 			switch s {


### PR DESCRIPTION
Remove credentials provider settings to allow the AWS go SDK to pull credentials from Instance Profile/Metadata.

This is similar to PR #15, but involves just commenting out the credentials provider section so the AWS go SDK can do it's thing.

Resolves the issues I am having with wal-g hanging on an instance with no .aws/credentials or similar.