### PR TITLE
Methods for storing objects with custom timestamps

### DIFF
--- a/memory/storage.go
+++ b/memory/storage.go
@@ -42,6 +42,10 @@ func (storage *Storage) Load(key string) (value TimeStampedData, exists bool) {
 	return valueInterface.(TimeStampedData), ok
 }
 
+func (storage *Storage) StoreWithCustomTimeStamp(key string, value bytes.Buffer, time TimeStampedData) {
+	storage.underlying.Store(key, time)
+}
+
 func (storage *Storage) Store(key string, value bytes.Buffer) {
 	storage.underlying.Store(key, TimeStampData(value))
 }


### PR DESCRIPTION
Tests for `backup-list` ordering requires mock storages with specific creation time. 

Related links:
[#907](https://github.com/wal-g/wal-g/pull/907) 