### PR TITLE
Close file after put in SSH storage

### DIFF
--- a/sh/folder.go
+++ b/sh/folder.go
@@ -175,6 +175,10 @@ func (folder *Folder) Exists(objectRelativePath string) (bool, error)  {
 	path := filepath.Join(folder.path, objectRelativePath)
 	_, err := folder.client.Stat(path)
 
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
 	if err != nil {
 		return false, NewFolderError(
 			err, "Fail check object existence '%s'", path,
@@ -233,6 +237,12 @@ func (folder *Folder) PutObject(name string, content io.Reader) error {
 			absolutePath,
 		)
 	}
-
+	err = file.Close()
+	if err != nil {
+		return NewFolderError(
+			err, "Fail write close file '%s'",
+			absolutePath,
+		)
+	}
 	return nil
 }

--- a/sh/folder_test.go
+++ b/sh/folder_test.go
@@ -1,0 +1,22 @@
+package sh
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/wal-g/storages/storage"
+	"testing"
+)
+
+func TestSHFolder(t *testing.T) {
+	t.Skip("Credentials needed to run SSH tests")
+
+	var storageFolder storage.Folder
+
+	storageFolder, err := ConfigureFolder("ssh://some.host/tmp/x",
+		map[string]string{
+			Username:       "x4mmm",
+			PrivateKeyPath: "/Users/x4mmm/.ssh/id_rsa_pg_tester"})
+
+	assert.NoError(t, err)
+
+	storage.RunFolderTest(storageFolder, t)
+}

--- a/sh/sftp.go
+++ b/sh/sftp.go
@@ -14,7 +14,7 @@ type SftpClient interface {
 	Remove(path string) error
 	Stat(p string) (os.FileInfo, error)
 	OpenFile(path string) (io.ReadCloser, error)
-	CreateFile(path string) (io.Writer, error)
+	CreateFile(path string) (*sftp.File, error)
 	Mkdir(path string) error
 }
 
@@ -26,7 +26,7 @@ func (client *extendedSftpClient) OpenFile(path string) (io.ReadCloser, error) {
 	return client.Open(path)
 }
 
-func (client *extendedSftpClient) CreateFile(path string) (io.Writer, error) {
+func (client *extendedSftpClient) CreateFile(path string) (*sftp.File, error) {
 	return client.Create(path)
 }
 

--- a/storage/testing.go
+++ b/storage/testing.go
@@ -39,7 +39,8 @@ func RunFolderTest(storageFolder Folder, t *testing.T) {
 	assert.NoError(t, err)
 	t.Log(subFolders[0].GetPath())
 	assert.Equal(t, "file0", objects[0].GetName())
-	assert.True(t, strings.HasSuffix(subFolders[0].GetPath(), "Sub1/"))
+	assert.True(t, strings.HasSuffix(subFolders[0].GetPath(), "Sub1/") ||
+		strings.HasSuffix(subFolders[0].GetPath(), "Sub1"))
 
 	sublist, subFolders, err := sub1.ListFolder()
 	assert.NoError(t, err)


### PR DESCRIPTION
Overflow of opened files sometimes caused broken backups. Fix this by closing files after upload.
This commit also adds some tests and fixes Exists() func of SH storage.